### PR TITLE
Feature/export sistr versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "3.6"
+  - "3.5"
+
+install:
+  - python setup.py install
+
+script: python setup.py test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Changed code to conform better to Python packaging standards.
 * Moved location of `config.ini` file so it gets properly included in Python package.
+* Add command-line option `--workflow-version` to export SISTR results from specific versions of the IRIDA SISTR workflow.
 
 # Version  0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Changed code to conform better to Python packaging standards.
 * Moved location of `config.ini` file so it gets properly included in Python package.
-* Add command-line option `--workflow-version` to export SISTR results from specific versions of the IRIDA SISTR workflow.
+* Add command-line option `--workflow` to export SISTR results from specific versions of the IRIDA SISTR workflow.
 
 # Version  0.4.0
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Example:
                 Exports all SISTR results from all projects to a file 'out.xlsx'
 
         irida-sistr-results -p 1 -p 2 -u irida-user -o out.xlsx
-                Exports SISTR results form projects [1,2] to a file 'out.xlsx'
+                Exports SISTR results from projects [1,2] to a file 'out.xlsx'
 
         irida-sistr-results -p 1 --workflow-version 0.3 -u irida-user -o out.xlsx
                 Exports only SISTR results from workflow version 0.3 form project [1]

--- a/README.md
+++ b/README.md
@@ -55,9 +55,11 @@ This will list each sample in project **1**, only including those results from t
 By default, results will come from any workflow version. A list of possible versions is shown when running `irida-sistr-results -h`.
 
 ```
-  -w WORKFLOW_VERSIONS, --workflow-version WORKFLOW_VERSIONS
-                        Only include results of these workflow version(s) ['0.1', '0.2', '0.3'] [all versions]
+  -w WORKFLOW_VERSIONS_OR_IDS, --workflow WORKFLOW_VERSIONS_OR_IDS
+                        Only include results of these workflow versions (or uuids) ['0.1', '0.2', '0.3'] [all versions]
 ```
+
+You may also pass the workflow UUID to `--workflow` instead of the version.
 
 # Installation
 
@@ -107,7 +109,7 @@ usage: irida-sistr-results [-h] [--irida-url IRIDA_URL]
                            [--output-tab TABULAR_FILE] [-o EXCEL_FILE]
                            [--include-user-results]
                            [--exclude-user-existing-results] [-T TIMEOUT]
-                           [-c CONFIG] [-V] [-w WORKFLOW_VERSIONS]
+                           [-c CONFIG] [-V] [-w WORKFLOW_VERSIONS_OR_IDS]
 
 Compile SISTR results from an IRIDA instance into a table.
 
@@ -142,8 +144,8 @@ optional arguments:
                         Configuration file for IRIDA (overrides values in 
                           ['irida_sistr_results/etc/config.ini', '~/.local/share/irida-sistr-results/config.ini'])
   -V, --version         show program's version number and exit
-  -w WORKFLOW_VERSIONS, --workflow-version WORKFLOW_VERSIONS
-                        Only include results of these workflow version(s) ['0.1', '0.2', '0.3'] [all versions]
+  -w WORKFLOW_VERSIONS_OR_IDS, --workflow WORKFLOW_VERSIONS_OR_IDS
+                        Only include results of these workflow versions (or uuids) ['0.1', '0.2', '0.3'] [all versions]
 
 Example:
         irida-sistr-results -a -u irida-user -o out.xlsx

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/phac-nml/irida-sistr-results.svg?branch=development)](https://travis-ci.org/phac-nml/irida-sistr-results)
+
 # IRIDA SISTR Results
 
 The IRIDA SISTR Results application enables the export of [SISTR][sistr-web] results that were run through [IRIDA][irida] (via the [sistr-cmd][sistr-cmd] application) to a spreadsheet. See the [IRIDA SISTR Pipeline][irida-sistr-pipeline] documentation for more details on the presentation of SISTR results in IRIDA.
@@ -7,7 +9,7 @@ The IRIDA SISTR Results application enables the export of [SISTR][sistr-web] res
 To export SISTR results from IRIDA to a spreadsheet, please run the following:
 
 ```bash
-irida-sistr-results.py -p 1 -p 2 -u irida-user -o out.xlsx
+irida-sistr-results -p 1 -p 2 -u irida-user -o out.xlsx
 ```
 
 This will log into the configured IRIDA instance using the username `irida-user` and export SISTR results for the projects with IDs 1 and 2 to a file `out.xlsx`.  See the [IRIDA Projects][irida-projects] documentation for more details on projects.
@@ -15,7 +17,7 @@ This will log into the configured IRIDA instance using the username `irida-user`
 Alternatively, instead of specifying individual projects you may use `-a` to export all projects.
 
 ```bash
-irida-sistr-results.py -a -u irida-user -o out.xlsx
+irida-sistr-results -a -u irida-user -o out.xlsx
 ```
 
 The exported file `out.xlsx` will look like the following:
@@ -25,7 +27,6 @@ The exported file `out.xlsx` will look like the following:
 This will list each sample in the given projects, as well as the associated SISTR results. The **QC Status** column will list one of **PASS**, **WARNING**, **FAIL**, or **MISSING** depending on the status of the results.  In particular, **MISSING** represents a sample with a missing SISTR result.
 
 In the case of multiple SISTR results per sample, IRIDA will load up that SISTR result which has a status of `PASS` that was run most recently for a particular sample.  To disable this behavior, please use `--exclude-user-existing-results`.
-
 
 ## Specify connection details
 
@@ -40,6 +41,23 @@ The connection details correspond to the details for an [IRIDA Client][irida-cli
 ## Include MISSING results
 
 To include results for **MISSING** samples you must re-run the data for these results in IRIDA and re-export the results to a table. To re-run in IRIDA please select the samples in question ([selecting samples by a text file][select-by-file] may be useful here) and resubmit these samples to the [SISTR Pipeline][irida-sistr-pipeline]. Please make sure to [Share pipeline results with a project][share-results-project], or you will not see the results.
+
+## Only include results from particular IRIDA/SISTR workflow verison
+
+You may restrict results to only come from a particular IRIDA/SISTR workflow version. For example:
+
+```bash
+irida-sistr-results -p 1 --workflow-version 0.3 -u irida-user -o out.xlsx
+```
+
+This will list each sample in project **1**, only including those results from the SISTR workflow version `0.3`.
+
+By default, results will come from any workflow version. A list of possible versions is shown when running `irida-sistr-results -h`.
+
+```
+  --workflow-version WORKFLOW_VERSION
+                        Only include results of this workflow version ['0.1', '0.2', '0.3'] [all versions]
+```
 
 # Installation
 
@@ -82,14 +100,15 @@ irida-sistr-results.py | grep '^ *-c' -A 1
 # Usage
 
 ```
-usage: irida-sistr-results.py [-h] [--irida-url IRIDA_URL]
-                              [--client-id CLIENT_ID]
-                              [--client-secret CLIENT_SECRET] [-u USERNAME]
-                              [--password PASSWORD] [-v] [-p PROJECTS] [-a]
-                              [--output-tab TABULAR_FILE] [-o EXCEL_FILE]
-                              [--include-user-results]
-                              [--exclude-user-existing-results] [-T TIMEOUT]
-                              [-c CONFIG] [-V]
+usage: irida-sistr-results [-h] [--irida-url IRIDA_URL]
+                           [--client-id CLIENT_ID]
+                           [--client-secret CLIENT_SECRET] [-u USERNAME]
+                           [--password PASSWORD] [-v] [-p PROJECTS] [-a]
+                           [--output-tab TABULAR_FILE] [-o EXCEL_FILE]
+                           [--include-user-results]
+                           [--exclude-user-existing-results] [-T TIMEOUT]
+                           [-c CONFIG] [-V]
+                           [--workflow-version WORKFLOW_VERSION]
 
 Compile SISTR results from an IRIDA instance into a table.
 
@@ -107,7 +126,8 @@ optional arguments:
   -v, --verbose         Turn on verbose logging.
   -p PROJECTS, --project PROJECTS
                         Projects to scan for SISTR results. If left blank will scan all projects the user has access to.
-  -a, --all-projects    Explicitly load results from all projects the user has access to.  Will ignore the values given in --project.
+  -a, --all-projects    Explicitly load results from all projects the user has access to.  Will ignore the values given
+                          in --project.
   --output-tab TABULAR_FILE, --to-tab-file TABULAR_FILE
                         Print results to tab-deliminited file.
   -o EXCEL_FILE, --output-excel EXCEL_FILE, --to-excel-file EXCEL_FILE
@@ -115,24 +135,31 @@ optional arguments:
   --include-user-results
                         Include SISTR analysis results run directly by the user.
   --exclude-user-existing-results
-                        If including user results, do not replace existing SISTR analysis that were automatically generated with user-run SISTR results.
+                        If including user results, do not replace existing SISTR analysis that were automatically
+                          generated with user-run SISTR results.
   -T TIMEOUT, --connection-timeout TIMEOUT
                         Connection timeout when getting results from IRIDA.
   -c CONFIG, --config CONFIG
-                        Configuration file for IRIDA (overrides values in ['/path/to/config.ini', '~/.local/share/irida-sistr-results/config.ini'])
+                        Configuration file for IRIDA (overrides values in 
+                          ['irida_sistr_results/etc/config.ini', '~/.local/share/irida-sistr-results/config.ini'])
   -V, --version         show program's version number and exit
+  --workflow-version WORKFLOW_VERSION
+                        Only include results of this workflow version ['0.1', '0.2', '0.3'] [all versions]
 
 Example:
-        irida-sistr-results.py -a -u irida-user -o out.xlsx
+        irida-sistr-results -a -u irida-user -o out.xlsx
                 Exports all SISTR results from all projects to a file 'out.xlsx'
 
-        irida-sistr-results.py -p 1 -p 2 -u irida-user -o out.xlsx
+        irida-sistr-results -p 1 -p 2 -u irida-user -o out.xlsx
                 Exports SISTR results form projects [1,2] to a file 'out.xlsx'
+
+        irida-sistr-results -p 1 --workflow-version 0.3 -u irida-user -o out.xlsx
+                Exports only SISTR results from workflow version 0.3 form project [1]
 ```
 
 # Legal
 
-Copyright 2017 Government of Canada
+Copyright 2018 Government of Canada
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this work except in compliance with the License. You may obtain a copy of the

--- a/README.md
+++ b/README.md
@@ -47,16 +47,16 @@ To include results for **MISSING** samples you must re-run the data for these re
 You may restrict results to only come from a particular IRIDA/SISTR workflow version. For example:
 
 ```bash
-irida-sistr-results -p 1 --workflow-version 0.3 -u irida-user -o out.xlsx
+irida-sistr-results -p 1 -w 0.3 -w 0.2 -u irida-user -o out.xlsx
 ```
 
-This will list each sample in project **1**, only including those results from the SISTR workflow version `0.3`.
+This will list each sample in project **1**, only including those results from the SISTR workflow versions `0.3` or `0.2`.
 
 By default, results will come from any workflow version. A list of possible versions is shown when running `irida-sistr-results -h`.
 
 ```
-  --workflow-version WORKFLOW_VERSION
-                        Only include results of this workflow version ['0.1', '0.2', '0.3'] [all versions]
+  -w WORKFLOW_VERSIONS, --workflow-version WORKFLOW_VERSIONS
+                        Only include results of these workflow version(s) ['0.1', '0.2', '0.3'] [all versions]
 ```
 
 # Installation
@@ -107,8 +107,7 @@ usage: irida-sistr-results [-h] [--irida-url IRIDA_URL]
                            [--output-tab TABULAR_FILE] [-o EXCEL_FILE]
                            [--include-user-results]
                            [--exclude-user-existing-results] [-T TIMEOUT]
-                           [-c CONFIG] [-V]
-                           [--workflow-version WORKFLOW_VERSION]
+                           [-c CONFIG] [-V] [-w WORKFLOW_VERSIONS]
 
 Compile SISTR results from an IRIDA instance into a table.
 
@@ -143,8 +142,8 @@ optional arguments:
                         Configuration file for IRIDA (overrides values in 
                           ['irida_sistr_results/etc/config.ini', '~/.local/share/irida-sistr-results/config.ini'])
   -V, --version         show program's version number and exit
-  --workflow-version WORKFLOW_VERSION
-                        Only include results of this workflow version ['0.1', '0.2', '0.3'] [all versions]
+  -w WORKFLOW_VERSIONS, --workflow-version WORKFLOW_VERSIONS
+                        Only include results of these workflow version(s) ['0.1', '0.2', '0.3'] [all versions]
 
 Example:
         irida-sistr-results -a -u irida-user -o out.xlsx
@@ -153,8 +152,8 @@ Example:
         irida-sistr-results -p 1 -p 2 -u irida-user -o out.xlsx
                 Exports SISTR results from projects [1,2] to a file 'out.xlsx'
 
-        irida-sistr-results -p 1 --workflow-version 0.3 -u irida-user -o out.xlsx
-                Exports only SISTR results from workflow version 0.3 form project [1]
+        irida-sistr-results -p 1 -w 0.3 -w 0.2 -u irida-user -o out.xlsx
+                Exports only SISTR results from workflow versions 0.3 and 0.2 from project [1]
 ```
 
 # Legal

--- a/bin/irida-sistr-results
+++ b/bin/irida-sistr-results
@@ -26,13 +26,23 @@ user_conf_file=os.path.join(user_conf_dir,'config.ini')
 
 logger=logging.getLogger("irida-sistr-results")
 
-def main(irida_url,client_id,client_secret,username,password,verbose,projects,tabular_file,excel_file,include_user_results,exclude_user_existing_results,all_projects,timeout,config):
+workflow_versions = {'0.1': 'e559af58-a560-4bbd-997e-808bfbe026e2',
+					 '0.2': 'e8f9cc61-3264-48c6-81d9-02d9e84bccc7',
+					 '0.3': '92ecf046-ee09-4271-b849-7a82625d6b60',
+					 '0.3.0': '92ecf046-ee09-4271-b849-7a82625d6b60'}
+
+def main(irida_url,client_id,client_secret,username,password,verbose,projects,tabular_file,excel_file,include_user_results,exclude_user_existing_results,all_projects,timeout,config,workflow_version):
 	"""Main method connecting to IRIDA/writing SISTR results file."""
 	logging.info("Running "+appname+" version "+version.__version__)
 
+	if workflow_version:
+		workflow_id = workflow_versions[workflow_version]
+	else:
+		workflow_id = None
+
 	connector = IridaConnector(client_id,client_secret,username,password,irida_url,timeout)
 	irida_api = IridaAPI(connector)
-	irida_results = IridaSistrResults(irida_api,include_user_results,not exclude_user_existing_results)
+	irida_results = IridaSistrResults(irida_api,include_user_results,not exclude_user_existing_results, workflow_id)
 	
 	if all_projects:
 		logger.info("Getting results for all projects in IRIDA. This may take a while.")
@@ -136,6 +146,7 @@ if __name__ == '__main__':
 	parser.add_argument('-T', '--connection-timeout', action='store', dest='timeout', help='Connection timeout when getting results from IRIDA.')
 	parser.add_argument('-c', '--config', action='store', dest='config', help='Configuration file for IRIDA (overrides values in '+str(get_conf_files())+')')
 	parser.add_argument('-V', '--version', action='version', version='%(prog)s {}'.format(version.__version__))
+	parser.add_argument('--workflow-version', action='store', dest='workflow_version', default=None, help="Only include results of this workflow version [all versions]")
 
 	if len(sys.argv)==1:
 		parser.print_help()

--- a/bin/irida-sistr-results
+++ b/bin/irida-sistr-results
@@ -149,7 +149,7 @@ if __name__ == '__main__':
 	arg_dict = vars(args)
 
 	if (arg_dict['verbose']):
-		logging.basicConfig(level=5, format='%(asctime)s %(levelname)s %(module)s.%(funcName)s,%(lineno)s: %(message)s')
+		logging.basicConfig(level=logging.DEBUG, format='%(asctime)s %(levelname)s %(module)s.%(funcName)s,%(lineno)s: %(message)s')
 	else:
 		logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s: %(message)s')
 

--- a/bin/irida-sistr-results
+++ b/bin/irida-sistr-results
@@ -16,30 +16,31 @@ from irida_sistr_results.sistr_writer import SistrCsvWriter, SistrExcelWriter
 from irida_sistr_results import version
 from irida_sistr_results.irida_sistr_workflow import IridaSistrWorkflow
 
-conf_dir=os.path.join(os.path.dirname(os.path.realpath(version.__file__)), 'etc')
-appname=os.path.basename(__file__)
+conf_dir = os.path.join(os.path.dirname(os.path.realpath(version.__file__)), 'etc')
+appname = os.path.basename(__file__)
 
-example_conf_file=os.path.join(conf_dir,'config.ini.example')
-conf_file = os.path.join(conf_dir,'config.ini')
+example_conf_file = os.path.join(conf_dir, 'config.ini.example')
+conf_file = os.path.join(conf_dir, 'config.ini')
 
-user_conf_dir=appdirs.user_data_dir(os.path.splitext(appname)[0])
-user_conf_file=os.path.join(user_conf_dir,'config.ini')
+user_conf_dir = appdirs.user_data_dir(os.path.splitext(appname)[0])
+user_conf_file = os.path.join(user_conf_dir, 'config.ini')
 
-logger=logging.getLogger("irida-sistr-results")
+logger = logging.getLogger("irida-sistr-results")
 
-def main(irida_url,client_id,client_secret,username,password,verbose,projects,tabular_file,excel_file,include_user_results,exclude_user_existing_results,all_projects,timeout,config,workflow_version):
+def main(irida_url, client_id, client_secret, username, password, verbose, projects, tabular_file, excel_file,
+         include_user_results, exclude_user_existing_results, all_projects, timeout, config, workflow_version):
 	"""Main method connecting to IRIDA/writing SISTR results file."""
-	logging.info("Running "+appname+" version "+version.__version__)
+	logging.info("Running " + appname + " version " + version.__version__)
 
-	connector = IridaConnector(client_id,client_secret,username,password,irida_url,timeout)
+	connector = IridaConnector(client_id, client_secret, username, password, irida_url, timeout)
 	irida_api = IridaAPI(connector)
-	irida_results = IridaSistrResults(irida_api,include_user_results,not exclude_user_existing_results,workflow_version)
+	irida_results = IridaSistrResults(irida_api, include_user_results, not exclude_user_existing_results, workflow_version)
 	
 	if all_projects:
 		logger.info("Getting results for all projects in IRIDA. This may take a while.")
 		sistr_list = irida_results.get_sistr_results_all_projects()
 	else:
-		logger.info("Getting results for projects: " + str(projects)+". This may take a while.")
+		logger.info("Getting results for projects: " + str(projects) + ". This may take a while.")
 		sistr_list = irida_results.get_sistr_results_from_projects(projects)
 
 	total_sample_results=0

--- a/bin/irida-sistr-results
+++ b/bin/irida-sistr-results
@@ -120,7 +120,7 @@ if __name__ == '__main__':
 			"\n\t" + appname + " -a -u irida-user -o out.xlsx"+
 			"\n\t\tExports all SISTR results from all projects to a file 'out.xlsx'"+
 			"\n\n\t" + appname + " -p 1 -p 2 -u irida-user -o out.xlsx"+
-			"\n\t\tExports SISTR results form projects [1,2] to a file 'out.xlsx'" +
+			"\n\t\tExports SISTR results from projects [1,2] to a file 'out.xlsx'" +
 			"\n\n\t" + appname + " -p 1 --workflow-version 0.3 -u irida-user -o out.xlsx" +
 			"\n\t\tExports only SISTR results from workflow version 0.3 form project [1]")
 

--- a/bin/irida-sistr-results
+++ b/bin/irida-sistr-results
@@ -28,13 +28,13 @@ user_conf_file = os.path.join(user_conf_dir, 'config.ini')
 logger = logging.getLogger("irida-sistr-results")
 
 def main(irida_url, client_id, client_secret, username, password, verbose, projects, tabular_file, excel_file,
-         include_user_results, exclude_user_existing_results, all_projects, timeout, config, workflow_version):
+         include_user_results, exclude_user_existing_results, all_projects, timeout, config, workflow_versions):
 	"""Main method connecting to IRIDA/writing SISTR results file."""
 	logging.info("Running " + appname + " version " + version.__version__)
 
 	connector = IridaConnector(client_id, client_secret, username, password, irida_url, timeout)
 	irida_api = IridaAPI(connector)
-	irida_results = IridaSistrResults(irida_api, include_user_results, not exclude_user_existing_results, workflow_version)
+	irida_results = IridaSistrResults(irida_api, include_user_results, not exclude_user_existing_results, workflow_versions)
 	
 	if all_projects:
 		logger.info("Getting results for all projects in IRIDA. This may take a while.")
@@ -122,8 +122,8 @@ if __name__ == '__main__':
 			"\n\t\tExports all SISTR results from all projects to a file 'out.xlsx'"+
 			"\n\n\t" + appname + " -p 1 -p 2 -u irida-user -o out.xlsx"+
 			"\n\t\tExports SISTR results from projects [1,2] to a file 'out.xlsx'" +
-			"\n\n\t" + appname + " -p 1 --workflow-version 0.3 -u irida-user -o out.xlsx" +
-			"\n\t\tExports only SISTR results from workflow version 0.3 form project [1]")
+			"\n\n\t" + appname + " -p 1 -w 0.3 -w 0.2 -u irida-user -o out.xlsx" +
+			"\n\t\tExports only SISTR results from workflow versions 0.3 and 0.2 from project [1]")
 
 	parser.add_argument('--irida-url', action='store', dest='irida_url', help='The URL to the IRIDA instance.')
 	parser.add_argument('--client-id', action='store', dest='client_id', help='The client id for an IRIDA instance.')
@@ -140,7 +140,7 @@ if __name__ == '__main__':
 	parser.add_argument('-T', '--connection-timeout', action='store', dest='timeout', help='Connection timeout when getting results from IRIDA.')
 	parser.add_argument('-c', '--config', action='store', dest='config', help='Configuration file for IRIDA (overrides values in '+str(get_conf_files())+')')
 	parser.add_argument('-V', '--version', action='version', version='%(prog)s {}'.format(version.__version__))
-	parser.add_argument('--workflow-version', action='store', dest='workflow_version', default=None, help="Only include results of this workflow version {} [all versions]".format(IridaSistrWorkflow.all_workflow_versions()))
+	parser.add_argument('-w', '--workflow-version', action='append', dest='workflow_versions', default=None, help="Only include results of these workflow version(s) {} [all versions]".format(IridaSistrWorkflow.all_workflow_versions()))
 
 	if len(sys.argv)==1:
 		parser.print_help()

--- a/bin/irida-sistr-results
+++ b/bin/irida-sistr-results
@@ -14,6 +14,7 @@ from irida_sistr_results.irida_api import IridaAPI
 from irida_sistr_results.irida_sistr_results import IridaSistrResults
 from irida_sistr_results.sistr_writer import SistrCsvWriter, SistrExcelWriter
 from irida_sistr_results import version
+from irida_sistr_results.irida_sistr_workflow import IridaSistrWorkflow
 
 conf_dir=os.path.join(os.path.dirname(os.path.realpath(version.__file__)), 'etc')
 appname=os.path.basename(__file__)
@@ -119,7 +120,9 @@ if __name__ == '__main__':
 			"\n\t" + appname + " -a -u irida-user -o out.xlsx"+
 			"\n\t\tExports all SISTR results from all projects to a file 'out.xlsx'"+
 			"\n\n\t" + appname + " -p 1 -p 2 -u irida-user -o out.xlsx"+
-			"\n\t\tExports SISTR results form projects [1,2] to a file 'out.xlsx'")
+			"\n\t\tExports SISTR results form projects [1,2] to a file 'out.xlsx'" +
+			"\n\n\t" + appname + " -p 1 --workflow-version 0.3 -u irida-user -o out.xlsx" +
+			"\n\t\tExports only SISTR results from workflow version 0.3 form project [1]")
 
 	parser.add_argument('--irida-url', action='store', dest='irida_url', help='The URL to the IRIDA instance.')
 	parser.add_argument('--client-id', action='store', dest='client_id', help='The client id for an IRIDA instance.')
@@ -136,7 +139,7 @@ if __name__ == '__main__':
 	parser.add_argument('-T', '--connection-timeout', action='store', dest='timeout', help='Connection timeout when getting results from IRIDA.')
 	parser.add_argument('-c', '--config', action='store', dest='config', help='Configuration file for IRIDA (overrides values in '+str(get_conf_files())+')')
 	parser.add_argument('-V', '--version', action='version', version='%(prog)s {}'.format(version.__version__))
-	parser.add_argument('--workflow-version', action='store', dest='workflow_version', default=None, help="Only include results of this workflow version [all versions]")
+	parser.add_argument('--workflow-version', action='store', dest='workflow_version', default=None, help="Only include results of this workflow version {} [all versions]".format(IridaSistrWorkflow.all_workflow_versions()))
 
 	if len(sys.argv)==1:
 		parser.print_help()

--- a/bin/irida-sistr-results
+++ b/bin/irida-sistr-results
@@ -28,13 +28,13 @@ user_conf_file = os.path.join(user_conf_dir, 'config.ini')
 logger = logging.getLogger("irida-sistr-results")
 
 def main(irida_url, client_id, client_secret, username, password, verbose, projects, tabular_file, excel_file,
-         include_user_results, exclude_user_existing_results, all_projects, timeout, config, workflow_versions):
+         include_user_results, exclude_user_existing_results, all_projects, timeout, config, workflow_versions_or_ids):
 	"""Main method connecting to IRIDA/writing SISTR results file."""
 	logging.info("Running " + appname + " version " + version.__version__)
 
 	connector = IridaConnector(client_id, client_secret, username, password, irida_url, timeout)
 	irida_api = IridaAPI(connector)
-	irida_results = IridaSistrResults(irida_api, include_user_results, not exclude_user_existing_results, workflow_versions)
+	irida_results = IridaSistrResults(irida_api, include_user_results, not exclude_user_existing_results, workflow_versions_or_ids)
 	
 	if all_projects:
 		logger.info("Getting results for all projects in IRIDA. This may take a while.")
@@ -140,7 +140,7 @@ if __name__ == '__main__':
 	parser.add_argument('-T', '--connection-timeout', action='store', dest='timeout', help='Connection timeout when getting results from IRIDA.')
 	parser.add_argument('-c', '--config', action='store', dest='config', help='Configuration file for IRIDA (overrides values in '+str(get_conf_files())+')')
 	parser.add_argument('-V', '--version', action='version', version='%(prog)s {}'.format(version.__version__))
-	parser.add_argument('-w', '--workflow-version', action='append', dest='workflow_versions', default=None, help="Only include results of these workflow version(s) {} [all versions]".format(IridaSistrWorkflow.all_workflow_versions()))
+	parser.add_argument('-w', '--workflow', action='append', dest='workflow_versions_or_ids', default=None, help="Only include results of these workflow versions (or uuids) {} [all versions]".format(IridaSistrWorkflow.all_workflow_versions()))
 
 	if len(sys.argv)==1:
 		parser.print_help()

--- a/bin/irida-sistr-results
+++ b/bin/irida-sistr-results
@@ -26,23 +26,13 @@ user_conf_file=os.path.join(user_conf_dir,'config.ini')
 
 logger=logging.getLogger("irida-sistr-results")
 
-workflow_versions = {'0.1': 'e559af58-a560-4bbd-997e-808bfbe026e2',
-					 '0.2': 'e8f9cc61-3264-48c6-81d9-02d9e84bccc7',
-					 '0.3': '92ecf046-ee09-4271-b849-7a82625d6b60',
-					 '0.3.0': '92ecf046-ee09-4271-b849-7a82625d6b60'}
-
 def main(irida_url,client_id,client_secret,username,password,verbose,projects,tabular_file,excel_file,include_user_results,exclude_user_existing_results,all_projects,timeout,config,workflow_version):
 	"""Main method connecting to IRIDA/writing SISTR results file."""
 	logging.info("Running "+appname+" version "+version.__version__)
 
-	if workflow_version:
-		workflow_id = workflow_versions[workflow_version]
-	else:
-		workflow_id = None
-
 	connector = IridaConnector(client_id,client_secret,username,password,irida_url,timeout)
 	irida_api = IridaAPI(connector)
-	irida_results = IridaSistrResults(irida_api,include_user_results,not exclude_user_existing_results, workflow_id)
+	irida_results = IridaSistrResults(irida_api,include_user_results,not exclude_user_existing_results,workflow_version)
 	
 	if all_projects:
 		logger.info("Getting results for all projects in IRIDA. This may take a while.")

--- a/bin/irida-sistr-results
+++ b/bin/irida-sistr-results
@@ -149,7 +149,7 @@ if __name__ == '__main__':
 	arg_dict = vars(args)
 
 	if (arg_dict['verbose']):
-		logging.basicConfig(level=logging.DEBUG, format='%(asctime)s %(levelname)s %(module)s.%(funcName)s,%(lineno)s: %(message)s')
+		logging.basicConfig(level=5, format='%(asctime)s %(levelname)s %(module)s.%(funcName)s,%(lineno)s: %(message)s')
 	else:
 		logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s: %(message)s')
 

--- a/irida_sistr_results/irida_api.py
+++ b/irida_sistr_results/irida_api.py
@@ -206,7 +206,7 @@ class IridaAPI(object):
 						logger.debug("Skipping sistr submission [id=%s, workflowId=%s]. workflowId != %s".format(
 							sistr['identifier'], sistr['workflowId'], sistr_workflow_id))
 				else:
-					logger.debug('Skipping incompleted sistr submission [id='+sistr['identifier']+']')
+					logger.debug('Skipping incompleted sistr submission [id=%s]', sistr['identifier'])
 			except (HTTPError, SistrResultsException) as e:
 				logger.warning('Could not read information for SISTR analysis submission id='+str(sistr['identifier'])+ ', name='+str(sistr['name']) + ', ignoring these results. '+str(e))
 

--- a/irida_sistr_results/irida_api.py
+++ b/irida_sistr_results/irida_api.py
@@ -74,12 +74,10 @@ class IridaAPI(object):
 			return sample
 	
 	def get_user_project(self,project_id):
-		"""Gets information on a particular IRIDA project
-
-		Args:
-		    project_id: The id of the project to search.
-
-		Returns:  The JSON results for the IRIDA project
+		"""
+		Gets information on a particular IRIDA project
+		:param project_id: The id of the project to search.
+		:return:  The JSON results for the IRIDA project
 		"""
 		return self.irida_connector.get('/api/projects/'+str(project_id))
 
@@ -91,15 +89,14 @@ class IridaAPI(object):
 		return self.irida_connector.get_resources('/api/projects')
 	
 	def get_sistr_results_for_project(self, project, sistr_workflow_id):
-		"""Gets information on all SISTR results in a project (that is, automated SISTR results).
-		   This is structured as a list of objects (on per sample) containing a SampleSistrInfo object if available and whether 
-		   or not these results are available for a sample (from keys 'has_results').
+		"""
+		Gets information on all SISTR results in a project (that is, automated SISTR results).
+		This is structured as a list of objects (on per sample) containing a SampleSistrInfo object if available and whether
+		or not these results are available for a sample (from keys 'has_results').
 
-		Args:
-		    :param project:  The project to search through.
-		    :param sistr_workflow_id: The SISTR workflow id, None for all workflow results.
-
-		Returns: A list of dictionaries containing SampleSistrInfo objects and/or indicators for missing results.
+		:param project:  The project to search through.
+		:param sistr_workflow_id: The SISTR workflow id, None for all workflow results.
+		:return: A list of dictionaries containing SampleSistrInfo objects and/or indicators for missing results.
 		"""
 		sistr_results=[]
 	
@@ -144,12 +141,11 @@ class IridaAPI(object):
 		return curr_sistr_info
 		
 	def get_sistr_info_from_submission(self, submission):
-		"""Gets the relevent SISTR information from an IRIDA SISTR AnalysisSubmission.
+		"""
+		Gets the relevent SISTR information from an IRIDA SISTR AnalysisSubmission.
 
-		Args:
-		    submission The IRIDA SISTR AnalysisSubmission data structure.
-
-		Returns: The SISTR information object (SampleSistrInfo) fro this submission.
+		:param submission: The IRIDA SISTR AnalysisSubmission data structure.
+		:return: The SISTR information object (SampleSistrInfo) fro this submission.
 		"""
 		sistr_info={}
 	
@@ -178,10 +174,10 @@ class IridaAPI(object):
 		return SampleSistrInfo(sistr_info)
 	
 	def get_sistr_submissions_for_user(self, sistr_workflow_id = None):
-		"""Gets all SISTR results accessible by a user (includes those submitted by a user or shared with a user via a project).
+		"""
+		Gets all SISTR results accessible by a user (includes those submitted by a user or shared with a user via a project).
 		:param workflow_version: The SISTR workflow ID, None for getting workflow results.
-
-		Returns:  A list of SampleSistrInfo objects that the current user has access to.
+		:return:  A list of SampleSistrInfo objects that the current user has access to.
 		"""
 		sistr_submissions_for_user=self.irida_connector.get_resources('/api/analysisSubmissions/analysisType/sistr')
 		

--- a/irida_sistr_results/irida_api.py
+++ b/irida_sistr_results/irida_api.py
@@ -108,45 +108,40 @@ class IridaAPI(object):
 		for sample in sistr_results_for_project:
 			sample_pairs=self.irida_connector.get_resources('/api/samples/'+sample['identifier']+'/pairs')
 
-			if len(sample_pairs) == 0:
-				sistr_info = SampleSistrInfo.create_empty_info(sample)
-			else:
-				sistr_info = None
+			sistr_info = SampleSistrInfo.create_empty_info(sample)
+
+			if len(sample_pairs) > 0:
 				for sequencing_object in sample_pairs:
 					if (self._has_rel_in_links('analysis/sistr', sequencing_object['links'])):
 						sistr_rel=self._get_rel_from_links('analysis/sistr', sequencing_object['links'])
 						sistr=self.irida_connector.get(sistr_rel)
-						
-						sistr_info = self._create_sample_sistr_info(sistr_workflow_id, sistr, sample, sequencing_object)
-					elif sistr_info is None:
-						sistr_info = SampleSistrInfo.create_empty_info(sample, sequencing_object)
+						new_sistr_info = self.get_sistr_info_from_submission(sistr)
+
+						if (sistr['analysisState'] != 'COMPLETED'):
+							logger.debug(
+								"Skipping automated SISTR results associated with sample=%s as state is not 'COMPLETED'.",
+								new_sistr_info.get_sample_id())
+						else:
+							sistr_info = self._update_sample_sistr_info(sistr_info, new_sistr_info, sistr_workflow_id)
 
 			sistr_results.append(sistr_info)
 		return sistr_results
 
-	def _create_sample_sistr_info(self, workflow_id, sistr, sample, sequencing_object):
-		sistr_info = SampleSistrInfo.create_empty_info(sample, sequencing_object)
-
-		if (sistr['analysisState'] != 'COMPLETED'):
-			logger.debug("Skipping automated SISTR results associated with sample=" + sample[
-				'sampleName'] + " as state is not 'COMPLETED'.")
+	def _update_sample_sistr_info(self, curr_sistr_info, new_sistr_info, sistr_workflow_id):
+		if sistr_workflow_id is None or sistr_workflow_id == new_sistr_info['workflowId']:
+			if not curr_sistr_info.has_sistr_results():
+				return new_sistr_info
+			elif new_sistr_info.get_qc_status() == 'PASS' and curr_sistr_info.get_qc_status() != 'PASS':
+				return new_sistr_info
+			elif new_sistr_info.get_qc_status() == 'PASS' and (
+					new_sistr_info.get_submission_created_date() > curr_sistr_info.get_submission_created_date()):
+				return new_sistr_info
 		else:
-			if workflow_id is None or workflow_id == sistr['workflowId']:
-				sistr_info_curr = self.get_sistr_info_from_submission(sistr)
-				if (sistr_info is None):
-					sistr_info = sistr_info_curr
-				elif sistr_info_curr.get_qc_status() == 'PASS' and (
-						not sistr_info.has_sistr_results() or sistr_info.get_qc_status() != 'PASS'):
-					sistr_info = sistr_info_curr
-				elif sistr_info_curr.get_qc_status() == 'PASS' and (
-						sistr_info_curr.get_submission_created_date() > sistr_info.get_submission_created_date()):
-					sistr_info = sistr_info_curr
-			else:
-				logger.debug(
-					"Skipping sistr submission [id=%s, workflowId=%s]. workflowId != %s".format(
-						sistr['identifier'], sistr['workflowId'], workflow_id))
+			logger.debug(
+				"Skipping sistr submission [id=%s, workflowId=%s]. workflowId != %s".format(
+					new_sistr_info.get_sample_id(), new_sistr_info.get_submission_workflow_id(), sistr_workflow_id))
 
-		return sistr_info
+		return curr_sistr_info
 		
 	def get_sistr_info_from_submission(self, submission):
 		"""Gets the relevent SISTR information from an IRIDA SISTR AnalysisSubmission.

--- a/irida_sistr_results/irida_api.py
+++ b/irida_sistr_results/irida_api.py
@@ -198,7 +198,6 @@ class IridaAPI(object):
 		sistr_analysis_list=[]
 		for sistr in sistr_submissions_for_user:
 			try:
-
 				if (sistr['analysisState'] == 'COMPLETED'):
 					if sistr_workflow_id is None or sistr_workflow_id == sistr['workflowId']:
 						sistr_analysis_list.append(self.get_sistr_info_from_submission(sistr))
@@ -231,7 +230,7 @@ class IridaAPI(object):
 					else:
 						logger.debug("Skipping sistr submission [id=%s, workflowId=%s]. workflowId != %s".format(sistr['identifier'], sistr['workflowId'], sistr_workflow_id))
 				else:
-					logger.debug('Skipping incompleted sistr submission [id=' + sistr['identifier'] + ']')
+					logger.debug('Skipping incompleted sistr submission [id=%s]', sistr['identifier'])
 			except (HTTPError, SistrResultsException) as e:
 				logger.warning('Could not read information for SISTR analysis submission id=' + str(
 					sistr['identifier']) + ', name=' + str(sistr['name']) + ', ignoring these results. ' + str(e))

--- a/irida_sistr_results/irida_api.py
+++ b/irida_sistr_results/irida_api.py
@@ -128,7 +128,7 @@ class IridaAPI(object):
 		return sistr_results
 
 	def _update_sample_sistr_info(self, curr_sistr_info, new_sistr_info, sistr_workflow_id):
-		if sistr_workflow_id is None or sistr_workflow_id == new_sistr_info['workflowId']:
+		if sistr_workflow_id is None or sistr_workflow_id == new_sistr_info.get_submission_workflow_id():
 			if not curr_sistr_info.has_sistr_results():
 				return new_sistr_info
 			elif new_sistr_info.get_qc_status() == 'PASS' and curr_sistr_info.get_qc_status() != 'PASS':

--- a/irida_sistr_results/irida_api.py
+++ b/irida_sistr_results/irida_api.py
@@ -115,13 +115,13 @@ class IridaAPI(object):
 					if (self._has_rel_in_links('analysis/sistr', sequencing_object['links'])):
 						sistr_rel=self._get_rel_from_links('analysis/sistr', sequencing_object['links'])
 						sistr=self.irida_connector.get(sistr_rel)
-						new_sistr_info = self.get_sistr_info_from_submission(sistr)
 
 						if (sistr['analysisState'] != 'COMPLETED'):
 							logger.debug(
 								"Skipping automated SISTR results associated with sample=%s as state is not 'COMPLETED'.",
-								new_sistr_info.get_sample_id())
+								sample['identifier'])
 						else:
+							new_sistr_info = self.get_sistr_info_from_submission(sistr)
 							sistr_info = self._update_sample_sistr_info(sistr_info, new_sistr_info, sistr_workflow_id)
 
 			sistr_results.append(sistr_info)

--- a/irida_sistr_results/irida_sistr_results.py
+++ b/irida_sistr_results/irida_sistr_results.py
@@ -6,19 +6,21 @@ logger=logging.getLogger("irida-sistr-results")
 class IridaSistrResults(object):
 	"""Class for constructing the top-level data structures mapping projects to lists of SISTR results."""
 
-	def __init__(self,irida_api,include_user_results,update_existing_with_user_results):
+	def __init__(self,irida_api,include_user_results,update_existing_with_user_results,sistr_workflow_id = None):
 		"""Creates a new IridaSistrResults object.
 
 		Args:
 		    irida_api:  The IridaAPI object for connecting to IRIDA.
 		    include_user_results:  Whether or not to include all user-accessible results (or just automated SISTR results).
 		    update_existing_with_user_results:  Whether or not to update existing results with newer results run by a user.
+		    sistr_workflow_id:	The SISTR workflow ID of results to include.
 
 		Returns:  A new IridaSistrResults object.
 		"""
 		self.irida_api=irida_api
 		self.include_user_results=include_user_results
 		self.update_existing_with_user_results=update_existing_with_user_results
+		self.sistr_workflow_id = sistr_workflow_id
 		self.sistr_results={}
 		self.sample_project={}
 
@@ -57,11 +59,11 @@ class IridaSistrResults(object):
 		return self.sistr_results
 
 	def _load_sistr_results_from_user(self):
-		user_results=self.irida_api.get_sistr_submissions_for_user()
+		user_results=self.irida_api.get_sistr_submissions_for_user(self.sistr_workflow_id)
 		self._load_additional_sistr_results(user_results)
 
 	def _load_sistr_results_shared_to_project(self, project_id):
-		project_results=self.irida_api.get_sistr_submissions_shared_to_project(project_id)
+		project_results=self.irida_api.get_sistr_submissions_shared_to_project(project_id, self.sistr_workflow_id)
 		self._load_additional_sistr_results(project_results)
 
 	def _load_additional_sistr_results(self,additional_results):
@@ -90,7 +92,7 @@ class IridaSistrResults(object):
 			raise Exception("Error: project " + str(project_id) + " already examined")
 		
 		self.sistr_results[project_id]={}
-		project_results=self.irida_api.get_sistr_results_for_project(project_id)
+		project_results=self.irida_api.get_sistr_results_for_project(project_id, self.sistr_workflow_id)
 
 		for result in project_results:
 			if result is None:

--- a/irida_sistr_results/irida_sistr_results.py
+++ b/irida_sistr_results/irida_sistr_results.py
@@ -1,26 +1,27 @@
 import logging
-from datetime import datetime
+
+from irida_sistr_results.irida_sistr_workflow import workflow_version_to_id
 
 logger=logging.getLogger("irida-sistr-results")
 
 class IridaSistrResults(object):
 	"""Class for constructing the top-level data structures mapping projects to lists of SISTR results."""
 
-	def __init__(self,irida_api,include_user_results,update_existing_with_user_results,sistr_workflow_id = None):
+	def __init__(self,irida_api,include_user_results,update_existing_with_user_results,sistr_workflow_version=None):
 		"""Creates a new IridaSistrResults object.
 
 		Args:
 		    irida_api:  The IridaAPI object for connecting to IRIDA.
 		    include_user_results:  Whether or not to include all user-accessible results (or just automated SISTR results).
 		    update_existing_with_user_results:  Whether or not to update existing results with newer results run by a user.
-		    sistr_workflow_id:	The SISTR workflow ID of results to include.
+		    sistr_workflow_version: The SISTR workflow version of results to include.
 
 		Returns:  A new IridaSistrResults object.
 		"""
 		self.irida_api=irida_api
 		self.include_user_results=include_user_results
 		self.update_existing_with_user_results=update_existing_with_user_results
-		self.sistr_workflow_id = sistr_workflow_id
+		self.sistr_workflow_id = workflow_version_to_id(sistr_workflow_version)
 		self.sistr_results={}
 		self.sample_project={}
 

--- a/irida_sistr_results/irida_sistr_results.py
+++ b/irida_sistr_results/irida_sistr_results.py
@@ -1,6 +1,6 @@
 import logging
 
-from irida_sistr_results.irida_sistr_workflow import workflow_version_to_id
+from irida_sistr_results.irida_sistr_workflow import IridaSistrWorkflow
 
 logger=logging.getLogger("irida-sistr-results")
 
@@ -21,7 +21,7 @@ class IridaSistrResults(object):
 		self.irida_api=irida_api
 		self.include_user_results=include_user_results
 		self.update_existing_with_user_results=update_existing_with_user_results
-		self.sistr_workflow_id = workflow_version_to_id(sistr_workflow_version)
+		self.sistr_workflow_id = IridaSistrWorkflow.workflow_version_to_id(sistr_workflow_version)
 		self.sistr_results={}
 		self.sample_project={}
 

--- a/irida_sistr_results/irida_sistr_results.py
+++ b/irida_sistr_results/irida_sistr_results.py
@@ -7,21 +7,21 @@ logger=logging.getLogger("irida-sistr-results")
 class IridaSistrResults(object):
 	"""Class for constructing the top-level data structures mapping projects to lists of SISTR results."""
 
-	def __init__(self,irida_api,include_user_results,update_existing_with_user_results,sistr_workflow_versions=None):
+	def __init__(self, irida_api, include_user_results, update_existing_with_user_results, sistr_workflow_versions_or_ids=None):
 		"""Creates a new IridaSistrResults object.
 
 		Args:
 		    irida_api:  The IridaAPI object for connecting to IRIDA.
 		    include_user_results:  Whether or not to include all user-accessible results (or just automated SISTR results).
 		    update_existing_with_user_results:  Whether or not to update existing results with newer results run by a user.
-		    sistr_workflow_versions: A list of SISTR workflow versions of results to include.
+		    sistr_workflow_versions_or_ids: A list of SISTR workflow versions (or UUIDs) of results to include.
 
 		Returns:  A new IridaSistrResults object.
 		"""
 		self.irida_api=irida_api
 		self.include_user_results=include_user_results
 		self.update_existing_with_user_results=update_existing_with_user_results
-		self.sistr_workflow_ids = IridaSistrWorkflow.workflow_versions_to_ids(sistr_workflow_versions)
+		self.sistr_workflow_ids = IridaSistrWorkflow.workflow_ids_or_versions_to_ids(sistr_workflow_versions_or_ids)
 		self.sistr_results={}
 		self.sample_project={}
 

--- a/irida_sistr_results/irida_sistr_results.py
+++ b/irida_sistr_results/irida_sistr_results.py
@@ -7,21 +7,21 @@ logger=logging.getLogger("irida-sistr-results")
 class IridaSistrResults(object):
 	"""Class for constructing the top-level data structures mapping projects to lists of SISTR results."""
 
-	def __init__(self,irida_api,include_user_results,update_existing_with_user_results,sistr_workflow_version=None):
+	def __init__(self,irida_api,include_user_results,update_existing_with_user_results,sistr_workflow_versions=None):
 		"""Creates a new IridaSistrResults object.
 
 		Args:
 		    irida_api:  The IridaAPI object for connecting to IRIDA.
 		    include_user_results:  Whether or not to include all user-accessible results (or just automated SISTR results).
 		    update_existing_with_user_results:  Whether or not to update existing results with newer results run by a user.
-		    sistr_workflow_version: The SISTR workflow version of results to include.
+		    sistr_workflow_versions: A list of SISTR workflow versions of results to include.
 
 		Returns:  A new IridaSistrResults object.
 		"""
 		self.irida_api=irida_api
 		self.include_user_results=include_user_results
 		self.update_existing_with_user_results=update_existing_with_user_results
-		self.sistr_workflow_id = IridaSistrWorkflow.workflow_version_to_id(sistr_workflow_version)
+		self.sistr_workflow_ids = IridaSistrWorkflow.workflow_versions_to_ids(sistr_workflow_versions)
 		self.sistr_results={}
 		self.sample_project={}
 
@@ -60,11 +60,11 @@ class IridaSistrResults(object):
 		return self.sistr_results
 
 	def _load_sistr_results_from_user(self):
-		user_results=self.irida_api.get_sistr_submissions_for_user(self.sistr_workflow_id)
+		user_results=self.irida_api.get_sistr_submissions_for_user(self.sistr_workflow_ids)
 		self._load_additional_sistr_results(user_results)
 
 	def _load_sistr_results_shared_to_project(self, project_id):
-		project_results=self.irida_api.get_sistr_submissions_shared_to_project(project_id, self.sistr_workflow_id)
+		project_results=self.irida_api.get_sistr_submissions_shared_to_project(project_id, self.sistr_workflow_ids)
 		self._load_additional_sistr_results(project_results)
 
 	def _load_additional_sistr_results(self,additional_results):
@@ -93,7 +93,7 @@ class IridaSistrResults(object):
 			raise Exception("Error: project " + str(project_id) + " already examined")
 		
 		self.sistr_results[project_id]={}
-		project_results=self.irida_api.get_sistr_results_for_project(project_id, self.sistr_workflow_id)
+		project_results=self.irida_api.get_sistr_results_for_project(project_id, self.sistr_workflow_ids)
 
 		for result in project_results:
 			if result is None:

--- a/irida_sistr_results/irida_sistr_workflow.py
+++ b/irida_sistr_results/irida_sistr_workflow.py
@@ -1,0 +1,23 @@
+WORKFLOW_IDS = {
+    '0.1': 'e559af58-a560-4bbd-997e-808bfbe026e2',
+    '0.2': 'e8f9cc61-3264-48c6-81d9-02d9e84bccc7',
+    '0.3': '92ecf046-ee09-4271-b849-7a82625d6b60',
+    None: None
+}
+WORKFLOW_VERSIONS = dict((v, k) for (k, v) in WORKFLOW_IDS.items())
+
+def workflow_id_to_version(workflow_id):
+    """
+    Converts an IRIDA workflow id to a version number.
+    :param workflow_id: The workflow id.
+    :return: The version number for the workflow.
+    """
+    return WORKFLOW_VERSIONS[workflow_id]
+
+def workflow_version_to_id(workflow_version):
+    """
+    Converts an IRIDA workflow version to an id.
+    :param workflow_version: The workflow version.
+    :return: The id of the workflow.
+    """
+    return WORKFLOW_IDS[workflow_version]

--- a/irida_sistr_results/irida_sistr_workflow.py
+++ b/irida_sistr_results/irida_sistr_workflow.py
@@ -1,3 +1,5 @@
+import uuid
+
 """
 Functionality for conversion between workflow ids and versions.
 """
@@ -46,6 +48,27 @@ class IridaSistrWorkflow:
         :return: The list of ids.
         """
         return None if workflow_versions is None else [cls.workflow_version_to_id(x) for x in workflow_versions]
+
+    @classmethod
+    def workflow_ids_or_versions_to_ids(cls, workflow_versions_or_ids):
+        """
+        Converts a list of IRIDA workflow versions or ids to a list of ids.
+        :param workflow_versions: The list of workflow versions or ids.
+        :return: The list of workflow ids.
+        """
+        if workflow_versions_or_ids is None:
+            return None
+        else:
+            ids_list = []
+            for value in workflow_versions_or_ids:
+                try:
+                    id = uuid.UUID('{' + value + '}')
+                    ids_list.append(str(id))
+                except ValueError:
+                    id = cls.workflow_version_to_id(value)
+                    ids_list.append(id)
+
+            return ids_list
 
     @classmethod
     def all_workflow_versions(cls):

--- a/irida_sistr_results/irida_sistr_workflow.py
+++ b/irida_sistr_results/irida_sistr_workflow.py
@@ -39,6 +39,15 @@ class IridaSistrWorkflow:
         return cls.WORKFLOW_IDS[workflow_version]
 
     @classmethod
+    def workflow_versions_to_ids(cls, workflow_versions):
+        """
+        Converts a list of IRIDA workflow versions to a list of ids.
+        :param workflow_versions: The list of workflow versions.
+        :return: The list of ids.
+        """
+        return None if workflow_versions is None else [cls.workflow_version_to_id(x) for x in workflow_versions]
+
+    @classmethod
     def all_workflow_versions(cls):
         """
         Gets a list of all workflow versions.

--- a/irida_sistr_results/irida_sistr_workflow.py
+++ b/irida_sistr_results/irida_sistr_workflow.py
@@ -1,23 +1,46 @@
-WORKFLOW_IDS = {
-    '0.1': 'e559af58-a560-4bbd-997e-808bfbe026e2',
-    '0.2': 'e8f9cc61-3264-48c6-81d9-02d9e84bccc7',
-    '0.3': '92ecf046-ee09-4271-b849-7a82625d6b60',
-    None: None
-}
-WORKFLOW_VERSIONS = dict((v, k) for (k, v) in WORKFLOW_IDS.items())
+class IridaSistrWorkflow:
+    """Functionality for conversion between workflow ids and versions."""
 
-def workflow_id_to_version(workflow_id):
-    """
-    Converts an IRIDA workflow id to a version number.
-    :param workflow_id: The workflow id.
-    :return: The version number for the workflow.
-    """
-    return WORKFLOW_VERSIONS[workflow_id]
+    WORKFLOW_IDS = {
+        '0.1': 'e559af58-a560-4bbd-997e-808bfbe026e2',
+        '0.1.0': 'e559af58-a560-4bbd-997e-808bfbe026e2',
+        '0.2': 'e8f9cc61-3264-48c6-81d9-02d9e84bccc7',
+        '0.2.0': 'e8f9cc61-3264-48c6-81d9-02d9e84bccc7',
+        '0.3': '92ecf046-ee09-4271-b849-7a82625d6b60',
+        '0.3.0': '92ecf046-ee09-4271-b849-7a82625d6b60',
+        None: None
+    }
+    WORKFLOW_VERSIONS = {
+        'e559af58-a560-4bbd-997e-808bfbe026e2': '0.1',
+        'e8f9cc61-3264-48c6-81d9-02d9e84bccc7': '0.2',
+        '92ecf046-ee09-4271-b849-7a82625d6b60': '0.3',
+        None: None
+    }
 
-def workflow_version_to_id(workflow_version):
-    """
-    Converts an IRIDA workflow version to an id.
-    :param workflow_version: The workflow version.
-    :return: The id of the workflow.
-    """
-    return WORKFLOW_IDS[workflow_version]
+    @classmethod
+    def workflow_id_to_version(cls,workflow_id):
+        """
+        Converts an IRIDA workflow id to a version number.
+        :param workflow_id: The workflow id.
+        :return: The version number for the workflow.
+        """
+        return cls.WORKFLOW_VERSIONS[workflow_id]
+
+    @classmethod
+    def workflow_version_to_id(cls,workflow_version):
+        """
+        Converts an IRIDA workflow version to an id.
+        :param workflow_version: The workflow version.
+        :return: The id of the workflow.
+        """
+        return cls.WORKFLOW_IDS[workflow_version]
+
+    @classmethod
+    def all_workflow_versions(cls):
+        """
+        Gets a list of all workflow versions.
+        :return: A list of all workflow versions.
+        """
+        versions = list(cls.WORKFLOW_VERSIONS.values())
+        versions.remove(None)
+        return versions

--- a/irida_sistr_results/irida_sistr_workflow.py
+++ b/irida_sistr_results/irida_sistr_workflow.py
@@ -1,6 +1,9 @@
-class IridaSistrWorkflow:
-    """Functionality for conversion between workflow ids and versions."""
+"""
+Functionality for conversion between workflow ids and versions.
+"""
 
+
+class IridaSistrWorkflow:
     WORKFLOW_IDS = {
         '0.1': 'e559af58-a560-4bbd-997e-808bfbe026e2',
         '0.1.0': 'e559af58-a560-4bbd-997e-808bfbe026e2',
@@ -18,7 +21,7 @@ class IridaSistrWorkflow:
     }
 
     @classmethod
-    def workflow_id_to_version(cls,workflow_id):
+    def workflow_id_to_version(cls, workflow_id):
         """
         Converts an IRIDA workflow id to a version number.
         :param workflow_id: The workflow id.
@@ -27,7 +30,7 @@ class IridaSistrWorkflow:
         return cls.WORKFLOW_VERSIONS[workflow_id]
 
     @classmethod
-    def workflow_version_to_id(cls,workflow_version):
+    def workflow_version_to_id(cls, workflow_version):
         """
         Converts an IRIDA workflow version to an id.
         :param workflow_version: The workflow version.

--- a/irida_sistr_results/sistr_info.py
+++ b/irida_sistr_results/sistr_info.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from irida_sistr_results.irida_sistr_workflow import workflow_id_to_version
+from irida_sistr_results.irida_sistr_workflow import IridaSistrWorkflow
 
 class SampleSistrInfo(object):
 	"""Stores and provides access to SISTR/IRIDA information for a particular sample."""
@@ -102,7 +102,7 @@ class SampleSistrInfo(object):
 		return self.sistr_info['submission']['workflowId']
 
 	def get_submission_workflow_version(self):
-		return workflow_id_to_version(self.get_submission_workflow_id())
+		return IridaSistrWorkflow.workflow_id_to_version(self.get_submission_workflow_id())
 
 	def get_submission_created_date(self):
 		return datetime.fromtimestamp(self.sistr_info['submission']['createdDate']/1000)

--- a/irida_sistr_results/sistr_info.py
+++ b/irida_sistr_results/sistr_info.py
@@ -8,6 +8,17 @@ class SampleSistrInfo(object):
 	def __init__(self, sistr_info):
 		self.sistr_info = sistr_info
 
+	@classmethod
+	def create_empty_info(cls, sample, sequencing_object = None):
+		data = {'sample': sample,
+				'has_results': False
+		}
+
+		if sequencing_object is not None:
+			data['paired_files'] = sequencing_object
+
+		return cls(data)
+
 	def has_sistr_results(self):
 		return self.sistr_info['has_results']
 

--- a/irida_sistr_results/sistr_info.py
+++ b/irida_sistr_results/sistr_info.py
@@ -96,6 +96,9 @@ class SampleSistrInfo(object):
 	def get_submission_identifier(self):
 		return self.sistr_info['submission']['identifier']
 
+	def get_submission_workflow_id(self):
+		return self.sistr_info['submission']['workflowId']
+
 	def get_submission_created_date(self):
 		return datetime.fromtimestamp(self.sistr_info['submission']['createdDate']/1000)
 

--- a/irida_sistr_results/sistr_info.py
+++ b/irida_sistr_results/sistr_info.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+from irida_sistr_results.irida_sistr_workflow import workflow_id_to_version
+
 class SampleSistrInfo(object):
 	"""Stores and provides access to SISTR/IRIDA information for a particular sample."""
 
@@ -98,6 +100,9 @@ class SampleSistrInfo(object):
 
 	def get_submission_workflow_id(self):
 		return self.sistr_info['submission']['workflowId']
+
+	def get_submission_workflow_version(self):
+		return workflow_id_to_version(self.get_submission_workflow_id())
 
 	def get_submission_created_date(self):
 		return datetime.fromtimestamp(self.sistr_info['submission']['createdDate']/1000)

--- a/irida_sistr_results/sistr_info.py
+++ b/irida_sistr_results/sistr_info.py
@@ -10,6 +10,12 @@ class SampleSistrInfo(object):
 
 	@classmethod
 	def create_empty_info(cls, sample, sequencing_object = None):
+		"""
+		Creates an empty SampleSistrInfo object (no SISTR results).
+		:param sample: The sample this object refers to.
+		:param sequencing_object: The sequencing object (default None).
+		:return: An empty SampleSistrInfo.
+		"""
 		data = {'sample': sample,
 				'has_results': False
 		}

--- a/irida_sistr_results/sistr_writer.py
+++ b/irida_sistr_results/sistr_writer.py
@@ -94,7 +94,8 @@ class SistrResultsWriter(object):
 			'IRIDA Sample Identifier',
 			'IRIDA File Pair Identifier',
 			'IRIDA Submission Identifier',
-			'IRIDA Analysis Date'
+			'IRIDA Analysis Date',
+			'IRIDA Workflow ID'
 		]
 
 	def _format_timestamp(self, timestamp):
@@ -145,7 +146,8 @@ class SistrResultsWriter(object):
 			result.get_sample_id(),
 			result.get_paired_id(),
 			result.get_submission_identifier(),
-			result.get_submission_created_date()
+			result.get_submission_created_date(),
+			result.get_submission_workflow_id(),
 		]
 
 	def _get_no_results_row_list(self,project,result):
@@ -182,6 +184,7 @@ class SistrResultsWriter(object):
 			None,
 			result.get_sample_created_date(),
 			result.get_sample_id(),
+			None,
 			None,
 			None,
 			None,
@@ -263,7 +266,8 @@ class SistrCsvWriter(SistrResultsWriter):
 			result.get_sample_id(),
 			result.get_paired_id(),
 			result.get_submission_identifier(),
-			result.get_submission_created_date()
+			result.get_submission_created_date(),
+			result.get_submission_workflow_id(),
 		]
 
 class SistrCsvWriterShort(SistrCsvWriter):

--- a/irida_sistr_results/sistr_writer.py
+++ b/irida_sistr_results/sistr_writer.py
@@ -95,7 +95,8 @@ class SistrResultsWriter(object):
 			'IRIDA File Pair Identifier',
 			'IRIDA Submission Identifier',
 			'IRIDA Analysis Date',
-			'IRIDA Workflow ID'
+			'IRIDA Workflow Version',
+			'IRIDA Workflow ID',
 		]
 
 	def _format_timestamp(self, timestamp):
@@ -147,6 +148,7 @@ class SistrResultsWriter(object):
 			result.get_paired_id(),
 			result.get_submission_identifier(),
 			result.get_submission_created_date(),
+			result.get_submission_workflow_version(),
 			result.get_submission_workflow_id(),
 		]
 
@@ -184,6 +186,7 @@ class SistrResultsWriter(object):
 			None,
 			result.get_sample_created_date(),
 			result.get_sample_id(),
+			None,
 			None,
 			None,
 			None,
@@ -267,6 +270,7 @@ class SistrCsvWriter(SistrResultsWriter):
 			result.get_paired_id(),
 			result.get_submission_identifier(),
 			result.get_submission_created_date(),
+			result.get_submission_workflow_version(),
 			result.get_submission_workflow_id(),
 		]
 

--- a/irida_sistr_results/tests/unit/test_irida_api.py
+++ b/irida_sistr_results/tests/unit/test_irida_api.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import Mock
 
 from irida_sistr_results.irida_api import IridaAPI
+from irida_sistr_results.sistr_info import SampleSistrInfo
 
 
 class IridaAPITest(unittest.TestCase):
@@ -28,6 +29,21 @@ class IridaAPITest(unittest.TestCase):
             'identifier': index,
             'name': 'sistr'
         } for index, workflow in enumerate(workflow_ids)]
+
+    def _create_sistr_info(self, workflow_id, qc_status, created_date):
+        return SampleSistrInfo({
+            'submission': {
+                'workflowId': workflow_id,
+                'createdDate': created_date
+            },
+            'has_results': True,
+            'sistr_predictions': [{
+                'qc_status': qc_status
+            }],
+            'sample': {
+                'identifier': '1',
+            }
+        })
 
     def test_get_sistr_submissions_for_user_single(self):
         self.connector.get_resources.return_value = self._create_user_results_state(['COMPLETED'])
@@ -67,7 +83,6 @@ class IridaAPITest(unittest.TestCase):
         sistr_results = self.irida_api.get_sistr_submissions_for_user('e8f9cc61-3264-48c6-81d9-02d9e84bccc7')
         self.assertEqual([1], sistr_results, "Should have correct identifiers")
 
-
     def test_get_sistr_submissions_for_project_multiple(self):
         self.connector.get_resources.return_value = self._create_user_results_state(['COMPLETED', 'COMPLETED'])
         sistr_results = self.irida_api.get_sistr_submissions_shared_to_project(1)
@@ -81,11 +96,107 @@ class IridaAPITest(unittest.TestCase):
     def test_get_sistr_submissions_for_project_one_workflow(self):
         self.connector.get_resources.return_value = self._create_user_results_workflow(
             ['92ecf046-ee09-4271-b849-7a82625d6b60', 'e8f9cc61-3264-48c6-81d9-02d9e84bccc7'])
-        sistr_results = self.irida_api.get_sistr_submissions_shared_to_project(1, '92ecf046-ee09-4271-b849-7a82625d6b60')
+        sistr_results = self.irida_api.get_sistr_submissions_shared_to_project(1,
+                                                                               '92ecf046-ee09-4271-b849-7a82625d6b60')
         self.assertEqual([0], sistr_results, "Should have correct identifiers")
 
     def test_get_sistr_submissions_for_project_other_workflow(self):
         self.connector.get_resources.return_value = self._create_user_results_workflow(
             ['92ecf046-ee09-4271-b849-7a82625d6b60', 'e8f9cc61-3264-48c6-81d9-02d9e84bccc7'])
-        sistr_results = self.irida_api.get_sistr_submissions_shared_to_project(1, 'e8f9cc61-3264-48c6-81d9-02d9e84bccc7')
+        sistr_results = self.irida_api.get_sistr_submissions_shared_to_project(1,
+                                                                               'e8f9cc61-3264-48c6-81d9-02d9e84bccc7')
         self.assertEqual([1], sistr_results, "Should have correct identifiers")
+
+    def test_update_sample_sistr_info_most_recent(self):
+        curr_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'PASS', 1500000000000)
+        new_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'PASS', 1500000000001)
+        updated_results = self.irida_api._update_sample_sistr_info(curr_sistr_info, new_sistr_info,
+                                                                   '92ecf046-ee09-4271-b849-7a82625d6b60')
+        self.assertEqual(new_sistr_info, updated_results, "Did not update to proper results")
+
+    def test_update_sample_sistr_info_skip_workflow(self):
+        curr_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'PASS', 1500000000000)
+        new_sistr_info = self._create_sistr_info('e8f9cc61-3264-48c6-81d9-02d9e84bccc7', 'PASS', 1500000000001)
+        updated_results = self.irida_api._update_sample_sistr_info(curr_sistr_info, new_sistr_info,
+                                                                   '92ecf046-ee09-4271-b849-7a82625d6b60')
+        self.assertEqual(curr_sistr_info, updated_results, "Did not update to proper results")
+
+    def test_update_sample_sistr_info_use_most_recent_all_workflows(self):
+        curr_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'PASS', 1500000000000)
+        new_sistr_info = self._create_sistr_info('e8f9cc61-3264-48c6-81d9-02d9e84bccc7', 'PASS', 1500000000001)
+        updated_results = self.irida_api._update_sample_sistr_info(curr_sistr_info, new_sistr_info, None)
+        self.assertEqual(new_sistr_info, updated_results, "Did not update to proper results")
+
+    def test_update_sample_sistr_info_equal_date(self):
+        curr_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'PASS', 1500000000000)
+        new_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'PASS', 1500000000000)
+        updated_results = self.irida_api._update_sample_sistr_info(curr_sistr_info, new_sistr_info,
+                                                                   '92ecf046-ee09-4271-b849-7a82625d6b60')
+        self.assertEqual(curr_sistr_info, updated_results, "Did not update to proper results")
+
+    def test_update_sample_sistr_info_pass(self):
+        curr_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'FAIL', 1500000000000)
+        new_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'PASS', 1500000000000)
+        updated_results = self.irida_api._update_sample_sistr_info(curr_sistr_info, new_sistr_info,
+                                                                   '92ecf046-ee09-4271-b849-7a82625d6b60')
+        self.assertEqual(new_sistr_info, updated_results, "Did not update to proper results")
+
+    def test_update_sample_sistr_info_fail(self):
+        curr_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'PASS', 1500000000000)
+        new_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'FAIL', 1500000000001)
+        updated_results = self.irida_api._update_sample_sistr_info(curr_sistr_info, new_sistr_info,
+                                                                   '92ecf046-ee09-4271-b849-7a82625d6b60')
+        self.assertEqual(curr_sistr_info, updated_results, "Did not update to proper results")
+
+    def test_update_sample_sistr_info_no_results(self):
+        curr_sistr_info = SampleSistrInfo.create_empty_info({
+            'sample': {
+                'identifier': '1',
+            }
+        })
+        new_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'PASS', 1500000000000)
+        updated_results = self.irida_api._update_sample_sistr_info(curr_sistr_info, new_sistr_info, None)
+        self.assertEqual(new_sistr_info, updated_results, "Did not update to proper results")
+
+    def test_update_sample_sistr_info_no_results_fail(self):
+        curr_sistr_info = SampleSistrInfo.create_empty_info({
+            'sample': {
+                'identifier': '1',
+            }
+        })
+        new_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'FAIL', 1500000000000)
+        updated_results = self.irida_api._update_sample_sistr_info(curr_sistr_info, new_sistr_info, None)
+        self.assertEqual(new_sistr_info, updated_results, "Did not update to proper results")
+
+    def test_update_sample_sistr_info_no_results_workflow_id(self):
+        curr_sistr_info = SampleSistrInfo.create_empty_info({
+            'sample': {
+                'identifier': '1',
+            }
+        })
+        new_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'PASS', 1500000000000)
+        updated_results = self.irida_api._update_sample_sistr_info(curr_sistr_info, new_sistr_info,
+                                                                   '92ecf046-ee09-4271-b849-7a82625d6b60')
+        self.assertEqual(new_sistr_info, updated_results, "Did not update to proper results")
+
+    def test_update_sample_sistr_info_no_results_workflow_id_fail(self):
+        curr_sistr_info = SampleSistrInfo.create_empty_info({
+            'sample': {
+                'identifier': '1',
+            }
+        })
+        new_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'FAIL', 1500000000000)
+        updated_results = self.irida_api._update_sample_sistr_info(curr_sistr_info, new_sistr_info,
+                                                                   '92ecf046-ee09-4271-b849-7a82625d6b60')
+        self.assertEqual(new_sistr_info, updated_results, "Did not update to proper results")
+
+    def test_update_sample_sistr_info_no_results_workflow_id_incorrect(self):
+        curr_sistr_info = SampleSistrInfo.create_empty_info({
+            'sample': {
+                'identifier': '1',
+            }
+        })
+        new_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'PASS', 1500000000000)
+        updated_results = self.irida_api._update_sample_sistr_info(curr_sistr_info, new_sistr_info,
+                                                                   'e8f9cc61-3264-48c6-81d9-02d9e84bccc7')
+        self.assertEqual(curr_sistr_info, updated_results, "Did not update to proper results")

--- a/irida_sistr_results/tests/unit/test_irida_api.py
+++ b/irida_sistr_results/tests/unit/test_irida_api.py
@@ -1,0 +1,50 @@
+import unittest
+from unittest.mock import patch
+from unittest.mock import Mock
+
+from irida_sistr_results.irida_api import IridaAPI
+
+class IridaAPITest(unittest.TestCase):
+
+    def setUp(self):
+        self.connector = Mock()
+        self.connector.get_resources = Mock()
+        self.irida_api = IridaAPI(self.connector)
+        self.irida_api.get_sistr_info_from_submission = Mock(side_effect=lambda x: x['identifier'])
+
+    def _create_user_results(self, analysis_states):
+        return [{
+            'analysisState': state,
+            'workflowId': '92ecf046-ee09-4271-b849-7a82625d6b60',
+            'identifier': index,
+            'name': 'sistr1'
+        } for index, state in enumerate(analysis_states)]
+
+    def test_get_sistr_submissions_for_user_single(self):
+        self.connector.get_resources.return_value = self._create_user_results(['COMPLETED'])
+
+        sistr_results = self.irida_api.get_sistr_submissions_for_user()
+
+        self.assertEqual([0], sistr_results, "Should have correct identifiers")
+
+    def test_get_sistr_submissions_for_user_multiple(self):
+        self.connector.get_resources.return_value = self._create_user_results(['COMPLETED', 'COMPLETED'])
+
+        sistr_results = self.irida_api.get_sistr_submissions_for_user()
+
+        self.assertEqual([0,1], sistr_results, "Should have correct identifiers")
+
+    def test_get_sistr_submissions_for_user_error(self):
+        self.connector.get_resources.return_value = self._create_user_results(['ERROR'])
+
+        sistr_results = self.irida_api.get_sistr_submissions_for_user()
+
+        self.assertEqual(0, len(sistr_results), "Should have empty results")
+
+    def test_get_sistr_submissions_for_user_error_one_success(self):
+        self.connector.get_resources.return_value = self._create_user_results(['COMPLETED', 'ERROR'])
+
+        sistr_results = self.irida_api.get_sistr_submissions_for_user()
+
+        self.assertEqual([0], sistr_results, "Should have empty results")
+

--- a/irida_sistr_results/tests/unit/test_irida_api.py
+++ b/irida_sistr_results/tests/unit/test_irida_api.py
@@ -74,14 +74,21 @@ class IridaAPITest(unittest.TestCase):
     def test_get_sistr_submissions_for_user_one_workflow(self):
         self.connector.get_resources.return_value = self._create_user_results_workflow(
             ['92ecf046-ee09-4271-b849-7a82625d6b60', 'e8f9cc61-3264-48c6-81d9-02d9e84bccc7'])
-        sistr_results = self.irida_api.get_sistr_submissions_for_user('92ecf046-ee09-4271-b849-7a82625d6b60')
+        sistr_results = self.irida_api.get_sistr_submissions_for_user(['92ecf046-ee09-4271-b849-7a82625d6b60'])
         self.assertEqual([0], sistr_results, "Should have correct identifiers")
 
     def test_get_sistr_submissions_for_user_other_workflow(self):
         self.connector.get_resources.return_value = self._create_user_results_workflow(
             ['92ecf046-ee09-4271-b849-7a82625d6b60', 'e8f9cc61-3264-48c6-81d9-02d9e84bccc7'])
-        sistr_results = self.irida_api.get_sistr_submissions_for_user('e8f9cc61-3264-48c6-81d9-02d9e84bccc7')
+        sistr_results = self.irida_api.get_sistr_submissions_for_user(['e8f9cc61-3264-48c6-81d9-02d9e84bccc7'])
         self.assertEqual([1], sistr_results, "Should have correct identifiers")
+
+    def test_get_sistr_submissions_for_user_both_workflows(self):
+        self.connector.get_resources.return_value = self._create_user_results_workflow(
+            ['92ecf046-ee09-4271-b849-7a82625d6b60', 'e8f9cc61-3264-48c6-81d9-02d9e84bccc7'])
+        sistr_results = self.irida_api.get_sistr_submissions_for_user(['92ecf046-ee09-4271-b849-7a82625d6b60',
+                                                                       'e8f9cc61-3264-48c6-81d9-02d9e84bccc7'])
+        self.assertEqual([0, 1], sistr_results, "Should have correct identifiers")
 
     def test_get_sistr_submissions_for_project_multiple(self):
         self.connector.get_resources.return_value = self._create_user_results_state(['COMPLETED', 'COMPLETED'])
@@ -97,29 +104,44 @@ class IridaAPITest(unittest.TestCase):
         self.connector.get_resources.return_value = self._create_user_results_workflow(
             ['92ecf046-ee09-4271-b849-7a82625d6b60', 'e8f9cc61-3264-48c6-81d9-02d9e84bccc7'])
         sistr_results = self.irida_api.get_sistr_submissions_shared_to_project(1,
-                                                                               '92ecf046-ee09-4271-b849-7a82625d6b60')
+                                                                               ['92ecf046-ee09-4271-b849-7a82625d6b60'])
         self.assertEqual([0], sistr_results, "Should have correct identifiers")
 
     def test_get_sistr_submissions_for_project_other_workflow(self):
         self.connector.get_resources.return_value = self._create_user_results_workflow(
             ['92ecf046-ee09-4271-b849-7a82625d6b60', 'e8f9cc61-3264-48c6-81d9-02d9e84bccc7'])
         sistr_results = self.irida_api.get_sistr_submissions_shared_to_project(1,
-                                                                               'e8f9cc61-3264-48c6-81d9-02d9e84bccc7')
+                                                                               ['e8f9cc61-3264-48c6-81d9-02d9e84bccc7'])
         self.assertEqual([1], sistr_results, "Should have correct identifiers")
+
+    def test_get_sistr_submissions_for_project_both_workflows(self):
+        self.connector.get_resources.return_value = self._create_user_results_workflow(
+            ['92ecf046-ee09-4271-b849-7a82625d6b60', 'e8f9cc61-3264-48c6-81d9-02d9e84bccc7'])
+        sistr_results = self.irida_api.get_sistr_submissions_shared_to_project(1, ['92ecf046-ee09-4271-b849-7a82625d6b60',
+                                                                                   'e8f9cc61-3264-48c6-81d9-02d9e84bccc7'])
+        self.assertEqual([0, 1], sistr_results, "Should have correct identifiers")
 
     def test_update_sample_sistr_info_most_recent(self):
         curr_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'PASS', 1500000000000)
         new_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'PASS', 1500000000001)
         updated_results = self.irida_api._update_sample_sistr_info(curr_sistr_info, new_sistr_info,
-                                                                   '92ecf046-ee09-4271-b849-7a82625d6b60')
+                                                                   ['92ecf046-ee09-4271-b849-7a82625d6b60'])
         self.assertEqual(new_sistr_info, updated_results, "Did not update to proper results")
 
     def test_update_sample_sistr_info_skip_workflow(self):
         curr_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'PASS', 1500000000000)
         new_sistr_info = self._create_sistr_info('e8f9cc61-3264-48c6-81d9-02d9e84bccc7', 'PASS', 1500000000001)
         updated_results = self.irida_api._update_sample_sistr_info(curr_sistr_info, new_sistr_info,
-                                                                   '92ecf046-ee09-4271-b849-7a82625d6b60')
+                                                                   ['92ecf046-ee09-4271-b849-7a82625d6b60'])
         self.assertEqual(curr_sistr_info, updated_results, "Did not update to proper results")
+
+    def test_update_sample_sistr_info_use_most_recent_both_workflows(self):
+        curr_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'PASS', 1500000000000)
+        new_sistr_info = self._create_sistr_info('e8f9cc61-3264-48c6-81d9-02d9e84bccc7', 'PASS', 1500000000001)
+        updated_results = self.irida_api._update_sample_sistr_info(curr_sistr_info, new_sistr_info,
+                                                                   ['92ecf046-ee09-4271-b849-7a82625d6b60',
+                                                                    'e8f9cc61-3264-48c6-81d9-02d9e84bccc7'])
+        self.assertEqual(new_sistr_info, updated_results, "Did not update to proper results")
 
     def test_update_sample_sistr_info_use_most_recent_all_workflows(self):
         curr_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'PASS', 1500000000000)
@@ -131,21 +153,21 @@ class IridaAPITest(unittest.TestCase):
         curr_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'PASS', 1500000000000)
         new_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'PASS', 1500000000000)
         updated_results = self.irida_api._update_sample_sistr_info(curr_sistr_info, new_sistr_info,
-                                                                   '92ecf046-ee09-4271-b849-7a82625d6b60')
+                                                                   ['92ecf046-ee09-4271-b849-7a82625d6b60'])
         self.assertEqual(curr_sistr_info, updated_results, "Did not update to proper results")
 
     def test_update_sample_sistr_info_pass(self):
         curr_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'FAIL', 1500000000000)
         new_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'PASS', 1500000000000)
         updated_results = self.irida_api._update_sample_sistr_info(curr_sistr_info, new_sistr_info,
-                                                                   '92ecf046-ee09-4271-b849-7a82625d6b60')
+                                                                   ['92ecf046-ee09-4271-b849-7a82625d6b60'])
         self.assertEqual(new_sistr_info, updated_results, "Did not update to proper results")
 
     def test_update_sample_sistr_info_fail(self):
         curr_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'PASS', 1500000000000)
         new_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'FAIL', 1500000000001)
         updated_results = self.irida_api._update_sample_sistr_info(curr_sistr_info, new_sistr_info,
-                                                                   '92ecf046-ee09-4271-b849-7a82625d6b60')
+                                                                   ['92ecf046-ee09-4271-b849-7a82625d6b60'])
         self.assertEqual(curr_sistr_info, updated_results, "Did not update to proper results")
 
     def test_update_sample_sistr_info_no_results(self):
@@ -176,7 +198,7 @@ class IridaAPITest(unittest.TestCase):
         })
         new_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'PASS', 1500000000000)
         updated_results = self.irida_api._update_sample_sistr_info(curr_sistr_info, new_sistr_info,
-                                                                   '92ecf046-ee09-4271-b849-7a82625d6b60')
+                                                                   ['92ecf046-ee09-4271-b849-7a82625d6b60'])
         self.assertEqual(new_sistr_info, updated_results, "Did not update to proper results")
 
     def test_update_sample_sistr_info_no_results_workflow_id_fail(self):
@@ -187,7 +209,7 @@ class IridaAPITest(unittest.TestCase):
         })
         new_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'FAIL', 1500000000000)
         updated_results = self.irida_api._update_sample_sistr_info(curr_sistr_info, new_sistr_info,
-                                                                   '92ecf046-ee09-4271-b849-7a82625d6b60')
+                                                                   ['92ecf046-ee09-4271-b849-7a82625d6b60'])
         self.assertEqual(new_sistr_info, updated_results, "Did not update to proper results")
 
     def test_update_sample_sistr_info_no_results_workflow_id_incorrect(self):
@@ -198,5 +220,5 @@ class IridaAPITest(unittest.TestCase):
         })
         new_sistr_info = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'PASS', 1500000000000)
         updated_results = self.irida_api._update_sample_sistr_info(curr_sistr_info, new_sistr_info,
-                                                                   'e8f9cc61-3264-48c6-81d9-02d9e84bccc7')
+                                                                   ['e8f9cc61-3264-48c6-81d9-02d9e84bccc7'])
         self.assertEqual(curr_sistr_info, updated_results, "Did not update to proper results")

--- a/irida_sistr_results/tests/unit/test_irida_api.py
+++ b/irida_sistr_results/tests/unit/test_irida_api.py
@@ -1,8 +1,8 @@
 import unittest
-from unittest.mock import patch
 from unittest.mock import Mock
 
 from irida_sistr_results.irida_api import IridaAPI
+
 
 class IridaAPITest(unittest.TestCase):
 
@@ -11,40 +11,81 @@ class IridaAPITest(unittest.TestCase):
         self.connector.get_resources = Mock()
         self.irida_api = IridaAPI(self.connector)
         self.irida_api.get_sistr_info_from_submission = Mock(side_effect=lambda x: x['identifier'])
+        self.irida_api._get_sistr_submission = Mock(side_effect=lambda x: {'identifier': x})
 
-    def _create_user_results(self, analysis_states):
+    def _create_user_results_state(self, analysis_states):
         return [{
             'analysisState': state,
             'workflowId': '92ecf046-ee09-4271-b849-7a82625d6b60',
             'identifier': index,
-            'name': 'sistr1'
+            'name': 'sistr'
         } for index, state in enumerate(analysis_states)]
 
+    def _create_user_results_workflow(self, workflow_ids):
+        return [{
+            'analysisState': 'COMPLETED',
+            'workflowId': workflow,
+            'identifier': index,
+            'name': 'sistr'
+        } for index, workflow in enumerate(workflow_ids)]
+
     def test_get_sistr_submissions_for_user_single(self):
-        self.connector.get_resources.return_value = self._create_user_results(['COMPLETED'])
-
+        self.connector.get_resources.return_value = self._create_user_results_state(['COMPLETED'])
         sistr_results = self.irida_api.get_sistr_submissions_for_user()
-
         self.assertEqual([0], sistr_results, "Should have correct identifiers")
 
     def test_get_sistr_submissions_for_user_multiple(self):
-        self.connector.get_resources.return_value = self._create_user_results(['COMPLETED', 'COMPLETED'])
-
+        self.connector.get_resources.return_value = self._create_user_results_state(['COMPLETED', 'COMPLETED'])
         sistr_results = self.irida_api.get_sistr_submissions_for_user()
-
-        self.assertEqual([0,1], sistr_results, "Should have correct identifiers")
+        self.assertEqual([0, 1], sistr_results, "Should have correct identifiers")
 
     def test_get_sistr_submissions_for_user_error(self):
-        self.connector.get_resources.return_value = self._create_user_results(['ERROR'])
-
+        self.connector.get_resources.return_value = self._create_user_results_state(['ERROR'])
         sistr_results = self.irida_api.get_sistr_submissions_for_user()
-
         self.assertEqual(0, len(sistr_results), "Should have empty results")
 
     def test_get_sistr_submissions_for_user_error_one_success(self):
-        self.connector.get_resources.return_value = self._create_user_results(['COMPLETED', 'ERROR'])
-
+        self.connector.get_resources.return_value = self._create_user_results_state(['COMPLETED', 'ERROR'])
         sistr_results = self.irida_api.get_sistr_submissions_for_user()
-
         self.assertEqual([0], sistr_results, "Should have empty results")
 
+    def test_get_sistr_submissions_for_user_default(self):
+        self.connector.get_resources.return_value = self._create_user_results_workflow(
+            ['92ecf046-ee09-4271-b849-7a82625d6b60', 'e8f9cc61-3264-48c6-81d9-02d9e84bccc7'])
+        sistr_results = self.irida_api.get_sistr_submissions_for_user()
+        self.assertEqual([0, 1], sistr_results, "Should have correct identifiers")
+
+    def test_get_sistr_submissions_for_user_one_workflow(self):
+        self.connector.get_resources.return_value = self._create_user_results_workflow(
+            ['92ecf046-ee09-4271-b849-7a82625d6b60', 'e8f9cc61-3264-48c6-81d9-02d9e84bccc7'])
+        sistr_results = self.irida_api.get_sistr_submissions_for_user('92ecf046-ee09-4271-b849-7a82625d6b60')
+        self.assertEqual([0], sistr_results, "Should have correct identifiers")
+
+    def test_get_sistr_submissions_for_user_other_workflow(self):
+        self.connector.get_resources.return_value = self._create_user_results_workflow(
+            ['92ecf046-ee09-4271-b849-7a82625d6b60', 'e8f9cc61-3264-48c6-81d9-02d9e84bccc7'])
+        sistr_results = self.irida_api.get_sistr_submissions_for_user('e8f9cc61-3264-48c6-81d9-02d9e84bccc7')
+        self.assertEqual([1], sistr_results, "Should have correct identifiers")
+
+
+    def test_get_sistr_submissions_for_project_multiple(self):
+        self.connector.get_resources.return_value = self._create_user_results_state(['COMPLETED', 'COMPLETED'])
+        sistr_results = self.irida_api.get_sistr_submissions_shared_to_project(1)
+        self.assertEqual([0, 1], sistr_results, "Should have correct identifiers")
+
+    def test_get_sistr_submissions_for_project_error_one_success(self):
+        self.connector.get_resources.return_value = self._create_user_results_state(['COMPLETED', 'ERROR'])
+        sistr_results = self.irida_api.get_sistr_submissions_shared_to_project(1)
+        self.assertEqual([0], sistr_results, "Should have empty results")
+
+    def test_get_sistr_submissions_for_project_one_workflow(self):
+        self.connector.get_resources.return_value = self._create_user_results_workflow(
+            ['92ecf046-ee09-4271-b849-7a82625d6b60', 'e8f9cc61-3264-48c6-81d9-02d9e84bccc7'])
+        sistr_results = self.irida_api.get_sistr_submissions_shared_to_project(1, '92ecf046-ee09-4271-b849-7a82625d6b60')
+        self.assertEqual([0], sistr_results, "Should have correct identifiers")
+
+    def test_get_sistr_submissions_for_project_other_workflow(self):
+        self.connector.get_resources.return_value = self._create_user_results_workflow(
+            ['92ecf046-ee09-4271-b849-7a82625d6b60', 'e8f9cc61-3264-48c6-81d9-02d9e84bccc7'])
+        sistr_results = self.irida_api.get_sistr_submissions_shared_to_project(1, 'e8f9cc61-3264-48c6-81d9-02d9e84bccc7')
+        self.assertEqual([1], sistr_results, "Should have correct identifiers")

--- a/irida_sistr_results/tests/unit/test_irida_api.py
+++ b/irida_sistr_results/tests/unit/test_irida_api.py
@@ -58,7 +58,7 @@ class IridaAPITest(unittest.TestCase):
     def test_get_sistr_submissions_for_user_error(self):
         self.connector.get_resources.return_value = self._create_user_results_state(['ERROR'])
         sistr_results = self.irida_api.get_sistr_submissions_for_user()
-        self.assertEqual(0, len(sistr_results), "Should have empty results")
+        self.assertEqual([], sistr_results, "Should have empty results")
 
     def test_get_sistr_submissions_for_user_error_one_success(self):
         self.connector.get_resources.return_value = self._create_user_results_state(['COMPLETED', 'ERROR'])

--- a/irida_sistr_results/tests/unit/test_irida_sistr_results.py
+++ b/irida_sistr_results/tests/unit/test_irida_sistr_results.py
@@ -1,0 +1,123 @@
+import unittest
+from unittest.mock import Mock
+
+from irida_sistr_results.irida_sistr_results import IridaSistrResults
+from irida_sistr_results.sistr_info import SampleSistrInfo
+
+
+class IridaSistrResultsTest(unittest.TestCase):
+
+    def setUp(self):
+        self.irida_api = Mock()
+        self.irida_sistr_results = IridaSistrResults(self.irida_api, False, True)
+
+    def _create_sistr_info(self, workflow_id, qc_status, created_date, sample_id):
+        return SampleSistrInfo({
+            'submission': {
+                'workflowId': workflow_id,
+                'createdDate': created_date,
+                'identifier': '1'
+            },
+            'has_results': True,
+            'sistr_predictions': [{
+                'qc_status': qc_status
+            }],
+            'sample': {
+                'identifier': str(sample_id),
+                'sampleName': 'name' + str(sample_id)
+            }
+        })
+
+    def _create_project_sistr_results(self, workflow_id, sample_ids):
+        return [self._create_sistr_info(workflow_id, 'PASS', 1500000000001, sample_id) for sample_id in sample_ids]
+
+    def _create_project_info(self, id):
+        return {
+            'identifier': str(id),
+            'name': 'project' + str(id),
+        }
+
+    def test_get_sistr_results_from_projects(self):
+        project_sistr_results = self._create_project_sistr_results('92ecf046-ee09-4271-b849-7a82625d6b60', [1, 2])
+        expected_results1 = project_sistr_results[0]
+        expected_results2 = project_sistr_results[1]
+
+        self.irida_api.get_user_project = Mock(return_value=self._create_project_info(1))
+        self.irida_api.get_sistr_results_for_project = Mock(return_value=project_sistr_results)
+        self.irida_api.get_sistr_submissions_shared_to_project = Mock(return_value=[])
+
+        results = self.irida_sistr_results.get_sistr_results_from_projects([1])
+
+        self.assertEqual(results, {'1': {'1': expected_results1, '2': expected_results2}},
+                         "Did not get expected SISTR results")
+
+    def test_get_sistr_results_from_projects_update_from_shared_date(self):
+        project_sistr_results = self._create_project_sistr_results('92ecf046-ee09-4271-b849-7a82625d6b60', [1])
+        shared_results = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'PASS', 1500000000002, 1)
+        expected_results = shared_results
+
+        self.irida_api.get_user_project = Mock(return_value=self._create_project_info(1))
+        self.irida_api.get_sistr_results_for_project = Mock(return_value=project_sistr_results)
+        self.irida_api.get_sistr_submissions_shared_to_project = Mock(return_value=[shared_results])
+
+        results = self.irida_sistr_results.get_sistr_results_from_projects([1])
+
+        self.assertEqual(results, {'1': {'1': expected_results}}, "Did not get expected SISTR results")
+
+    def test_get_sistr_results_from_projects_update_from_shared_fail(self):
+        project_sistr_results = self._create_project_sistr_results('92ecf046-ee09-4271-b849-7a82625d6b60', [1])
+        shared_results = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'FAIL', 1500000000002, 1)
+        expected_results = shared_results
+
+        self.irida_api.get_user_project = Mock(return_value=self._create_project_info(1))
+        self.irida_api.get_sistr_results_for_project = Mock(return_value=project_sistr_results)
+        self.irida_api.get_sistr_submissions_shared_to_project = Mock(return_value=[shared_results])
+
+        results = self.irida_sistr_results.get_sistr_results_from_projects([1])
+
+        self.assertEqual(results, {'1': {'1': expected_results}}, "Did not get expected SISTR results")
+
+    def test_get_sistr_results_from_projects_no_update_from_shared_date(self):
+        project_sistr_results = self._create_project_sistr_results('92ecf046-ee09-4271-b849-7a82625d6b60', [1])
+        shared_results = self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'PASS', 1500000000000, 1)
+        expected_results = project_sistr_results[0]
+
+        self.irida_api.get_user_project = Mock(return_value=self._create_project_info(1))
+        self.irida_api.get_sistr_results_for_project = Mock(return_value=project_sistr_results)
+        self.irida_api.get_sistr_submissions_shared_to_project = Mock(return_value=[shared_results])
+
+        results = self.irida_sistr_results.get_sistr_results_from_projects([1])
+
+        self.assertEqual(results, {'1': {'1': expected_results}}, "Did not get expected SISTR results")
+
+    def test_get_sistr_results_from_projects_multipleshared_update_pass(self):
+        project_sistr_results = self._create_project_sistr_results('92ecf046-ee09-4271-b849-7a82625d6b60', [1])
+        shared_results = [
+            self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'FAIL', 1500000000002, 1),
+            self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'PASS', 1500000000003, 1)
+        ]
+        expected_results = shared_results[1]
+
+        self.irida_api.get_user_project = Mock(return_value=self._create_project_info(1))
+        self.irida_api.get_sistr_results_for_project = Mock(return_value=project_sistr_results)
+        self.irida_api.get_sistr_submissions_shared_to_project = Mock(return_value=shared_results)
+
+        results = self.irida_sistr_results.get_sistr_results_from_projects([1])
+
+        self.assertEqual(results, {'1': {'1': expected_results}}, "Did not get expected SISTR results")
+
+    def test_get_sistr_results_from_projects_multipleshared_update_fail_switch_order(self):
+        project_sistr_results = self._create_project_sistr_results('92ecf046-ee09-4271-b849-7a82625d6b60', [1])
+        shared_results = [
+            self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'PASS', 1500000000002, 1),
+            self._create_sistr_info('92ecf046-ee09-4271-b849-7a82625d6b60', 'FAIL', 1500000000003, 1)
+        ]
+        expected_results = shared_results[1]
+
+        self.irida_api.get_user_project = Mock(return_value=self._create_project_info(1))
+        self.irida_api.get_sistr_results_for_project = Mock(return_value=project_sistr_results)
+        self.irida_api.get_sistr_submissions_shared_to_project = Mock(return_value=shared_results)
+
+        results = self.irida_sistr_results.get_sistr_results_from_projects([1])
+
+        self.assertEqual(results, {'1': {'1': expected_results}}, "Did not get expected SISTR results")

--- a/irida_sistr_results/tests/unit/test_irida_sistr_workflow.py
+++ b/irida_sistr_results/tests/unit/test_irida_sistr_workflow.py
@@ -1,0 +1,27 @@
+import unittest
+
+from irida_sistr_results.irida_sistr_workflow import IridaSistrWorkflow
+
+
+class IridaSistrWorkflowTest(unittest.TestCase):
+
+    def test_workflow_ids_or_versions_to_ids_version(self):
+        ids = IridaSistrWorkflow.workflow_ids_or_versions_to_ids(['0.1'])
+
+        self.assertEqual(['e559af58-a560-4bbd-997e-808bfbe026e2'], ids, "Invalid ids")
+
+    def test_workflow_ids_or_versions_to_ids_id(self):
+        ids = IridaSistrWorkflow.workflow_ids_or_versions_to_ids(['e559af58-a560-4bbd-997e-808bfbe026e2'])
+
+        self.assertEqual(['e559af58-a560-4bbd-997e-808bfbe026e2'], ids, "Invalid ids")
+
+    def test_workflow_ids_or_versions_to_ids_id_and_version(self):
+        ids = IridaSistrWorkflow.workflow_ids_or_versions_to_ids(['e559af58-a560-4bbd-997e-808bfbe026e2', '0.2'])
+
+        self.assertEqual(['e559af58-a560-4bbd-997e-808bfbe026e2', 'e8f9cc61-3264-48c6-81d9-02d9e84bccc7'], ids, "Invalid ids")
+
+    def test_workflow_ids_or_versions_to_ids_invalid_version(self):
+        self.assertRaises(KeyError, IridaSistrWorkflow.workflow_ids_or_versions_to_ids, ['0.1x'])
+
+    def test_workflow_ids_or_versions_to_ids_invalid_id(self):
+        self.assertRaises(KeyError, IridaSistrWorkflow.workflow_ids_or_versions_to_ids, ['Xe8f9cc61-3264-48c6-81d9-02d9e84bccc7'])

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ setup(name='irida-sistr-results',
           'XlsxWriter>=0.9.8',
           'appdirs>=1.4.3'
       ],
+      test_suite='nose.collector',
+      tests_require=['nose'],
       packages=find_packages(),
       include_package_data=True,
       scripts=['bin/irida-sistr-results']


### PR DESCRIPTION
This adds a new command-line option `--worklow-version` to export SISTR results from only specific IRIDA/SISTR workflows. Fixes issue #3 

This also adds a test suite and some unit tests.